### PR TITLE
Change to portability for merging to prevent duplicate links on import.

### DIFF
--- a/LinksController.vb
+++ b/LinksController.vb
@@ -66,6 +66,13 @@ Namespace DotNetNuke.Modules.Links
 
         End Sub
 
+        Public Sub DeleteOldLinksForModule(ByVal ModuleId as Integer)
+            
+            For Each oldLink In GetLinks(ModuleId)
+                DeleteLink(oldLink.ItemID, ModuleId)
+            Next
+        End Sub
+
         ''' <summary>
         ''' Function evaluates the targets content and tries to build a summary about the targets title and description.
         ''' </summary>
@@ -372,6 +379,9 @@ Namespace DotNetNuke.Modules.Links
         Public Sub ImportModule(ByVal ModuleID As Integer, ByVal Content As String, ByVal Version As String, ByVal UserId As Integer) Implements Entities.Modules.IPortable.ImportModule
             Dim xmlLink As XmlNode
             Dim xmlLinks As XmlNode = GetContent(Content, "links")
+            If xmlLinks.SelectNodes("link").Count >= 1
+                DeleteOldLinksForModule(ModuleID)
+            End If
             For Each xmlLink In xmlLinks.SelectNodes("link")
                 Dim objLink As New LinkInfo
                 objLink.ModuleId = ModuleID

--- a/LinksController.vb
+++ b/LinksController.vb
@@ -66,10 +66,12 @@ Namespace DotNetNuke.Modules.Links
 
         End Sub
 
-        Public Sub DeleteOldLinksForModule(ByVal ModuleId as Integer)
+        Public Sub DeleteLinkIfItExistsForModule(ByVal ModuleId As Integer, ByVal objLink as LinkInfo)
             
             For Each oldLink In GetLinks(ModuleId)
-                DeleteLink(oldLink.ItemID, ModuleId)
+                If oldLink.Title = objLink.Title And oldLink.Url = objLink.Url
+                    DeleteLink(oldLink.ItemID, ModuleId)
+                End If
             Next
         End Sub
 
@@ -379,9 +381,6 @@ Namespace DotNetNuke.Modules.Links
         Public Sub ImportModule(ByVal ModuleID As Integer, ByVal Content As String, ByVal Version As String, ByVal UserId As Integer) Implements Entities.Modules.IPortable.ImportModule
             Dim xmlLink As XmlNode
             Dim xmlLinks As XmlNode = GetContent(Content, "links")
-            If xmlLinks.SelectNodes("link").Count >= 1
-                DeleteOldLinksForModule(ModuleID)
-            End If
             For Each xmlLink In xmlLinks.SelectNodes("link")
                 Dim objLink As New LinkInfo
                 objLink.ModuleId = ModuleID
@@ -397,6 +396,7 @@ Namespace DotNetNuke.Modules.Links
                 End Try
                 objLink.CreatedDate = DateTime.Now()
                 objLink.CreatedByUser = UserId
+                DeleteLinkIfItExistsForModule(ModuleID, objLink)
                 AddLink(objLink)
 
                 ' url tracking


### PR DESCRIPTION
Instead of just inserting all new links and having the possibility of duplicates after import, I added some logic to check if that link existed based on Title and Url and if it did, we will delete it and then re-insert the new one in case the settings are different. This was a change that I needed to make for Server to Server portability. I don't see this ever happening on Portal importing, but this could happen on Module importing as well. Feel free to email me at JBradley@engagesoftware.com, or reach out on Twitter @JrBradley1
