### PR TITLE
Fixed build issues

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -8,6 +8,6 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: System.Reflection.AssemblyVersion("7.0.0.00")]
+[assembly: System.Reflection.AssemblyVersion("7.0.1.00")]
 
 

--- a/DNN_Links.dnn
+++ b/DNN_Links.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="DNN_Links" type="Module" version="7.0.0">
+    <package name="DNN_Links" type="Module" version="7.0.1">
       <friendlyName>Links</friendlyName>
       <description>This module renders a list of hyperlinks. Links includes an edit page, which allows authorized users to edit the Links data stored in the SQL database.</description>
       <iconFile>img/links-icon.png</iconFile>
@@ -14,7 +14,7 @@
       <releaseNotes src="ReleaseNotes.htm" />
       <azureCompatible>true</azureCompatible>
       <dependencies>
-        <dependency type="coreVersion">07.02.00</dependency>
+        <dependency type="coreVersion">08.00.00</dependency>
       </dependencies>
       <components>
         <component type="Config">

--- a/Dnn.Links.csproj
+++ b/Dnn.Links.csproj
@@ -45,97 +45,32 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ClientDependency.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\ClientDependency.Core.dll</HintPath>
+    <Reference Include="DotNetNuke, Version=8.0.0.809, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Core.8.0.0.809\lib\net40\DotNetNuke.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DNN.Integration.Test.Framework, Version=9.2.0.366, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.2.0.366\lib\DNN.Integration.Test.Framework.dll</HintPath>
+    <Reference Include="DotNetNuke.Web, Version=8.0.0.809, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Web.8.0.0.809\lib\net40\DotNetNuke.Web.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Core.9.1.1.129\lib\net40\DotNetNuke.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.HttpModules, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.HttpModules.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Instrumentation, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Instrumentation.9.1.1.129\lib\net40\DotNetNuke.Instrumentation.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Log4Net, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Instrumentation.9.1.1.129\lib\net40\DotNetNuke.Log4Net.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Modules.DigitalAssets, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.Modules.DigitalAssets.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Tests.Data, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.Tests.Data.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Tests.Utilities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.Tests.Utilities.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Web, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.9.1.1.129\lib\net40\DotNetNuke.Web.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Web.Client, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Client.9.1.1.129\lib\net40\DotNetNuke.Web.Client.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Web.Deprecated, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Deprecated.9.1.1.129\lib\net40\DotNetNuke.Web.Deprecated.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.Web.Mvc, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Mvc.9.1.1.129\lib\net45\DotNetNuke.Web.Mvc.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="DotNetNuke.WebControls, Version=2.4.0.598, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.WebControls.dll</HintPath>
+    <Reference Include="DotNetNuke.Web.Deprecated, Version=8.0.0.809, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Web.Deprecated.8.0.0.809\lib\net40\DotNetNuke.Web.Deprecated.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="DotNetNuke.WebUtility, Version=4.2.1.783, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.9.1.1.129\lib\net40\DotNetNuke.WebUtility.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FiftyOne.Foundation, Version=3.2.3.2, Culture=neutral, PublicKeyToken=e967ae578dabd98e, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\FiftyOne.Foundation.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Web.Deprecated.8.0.0.809\lib\net40\DotNetNuke.WebUtility.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationBlocks.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Core.9.1.1.129\lib\net40\Microsoft.ApplicationBlocks.Data.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Core.8.0.0.809\lib\net40\Microsoft.ApplicationBlocks.Data.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.4.5.6\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Core" />
@@ -147,15 +82,11 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="Telerik.Web.UI, Version=2013.2.717.40, Culture=neutral, PublicKeyToken=121fae78165ba3d4, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Deprecated.9.1.1.129\lib\net40\Telerik.Web.UI.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Web.Deprecated.8.0.0.809\lib\net40\Telerik.Web.UI.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>

--- a/Dnn.Links.csproj
+++ b/Dnn.Links.csproj
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ClientDependency.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.2.0.366\lib\ClientDependency.Core.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\ClientDependency.Core.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
@@ -55,68 +55,78 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke, Version=9.2.0.73, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Core.9.2.0.73\lib\net40\DotNetNuke.dll</HintPath>
+    <Reference Include="DotNetNuke, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Core.9.1.1.129\lib\net40\DotNetNuke.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke.HttpModules, Version=9.2.0.366, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.2.0.366\lib\DotNetNuke.HttpModules.dll</HintPath>
+    <Reference Include="DotNetNuke.HttpModules, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.HttpModules.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke.Instrumentation, Version=9.2.0.101, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Instrumentation.9.2.0.101\lib\net40\DotNetNuke.Instrumentation.dll</HintPath>
+    <Reference Include="DotNetNuke.Instrumentation, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Instrumentation.9.1.1.129\lib\net40\DotNetNuke.Instrumentation.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="DotNetNuke.Log4Net, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Instrumentation.9.2.0.101\lib\net40\DotNetNuke.Log4Net.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Instrumentation.9.1.1.129\lib\net40\DotNetNuke.Log4Net.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke.Modules.DigitalAssets, Version=9.2.0.366, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.2.0.366\lib\DotNetNuke.Modules.DigitalAssets.dll</HintPath>
+    <Reference Include="DotNetNuke.Modules.DigitalAssets, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.Modules.DigitalAssets.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DotNetNuke.Tests.Data, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.Tests.Data.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="DotNetNuke.Tests.Utilities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.2.0.366\lib\DotNetNuke.Tests.Utilities.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.Tests.Utilities.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke.Web, Version=9.2.0.101, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.9.2.0.101\lib\net40\DotNetNuke.Web.dll</HintPath>
+    <Reference Include="DotNetNuke.Web, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Web.9.1.1.129\lib\net40\DotNetNuke.Web.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke.Web.Client, Version=9.2.0.101, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Client.9.2.0.101\lib\net40\DotNetNuke.Web.Client.dll</HintPath>
+    <Reference Include="DotNetNuke.Web.Client, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Web.Client.9.1.1.129\lib\net40\DotNetNuke.Web.Client.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke.Web.Deprecated, Version=9.2.0.101, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Deprecated.9.2.0.101\lib\net40\DotNetNuke.Web.Deprecated.dll</HintPath>
+    <Reference Include="DotNetNuke.Web.Deprecated, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Web.Deprecated.9.1.1.129\lib\net40\DotNetNuke.Web.Deprecated.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DotNetNuke.Web.Mvc, Version=9.2.0.101, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Mvc.9.2.0.101\lib\net45\DotNetNuke.Web.Mvc.dll</HintPath>
+    <Reference Include="DotNetNuke.Web.Mvc, Version=9.1.1.129, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Web.Mvc.9.1.1.129\lib\net45\DotNetNuke.Web.Mvc.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="DotNetNuke.WebControls, Version=2.4.0.598, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Bundle.9.2.0.366\lib\DotNetNuke.WebControls.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\DotNetNuke.WebControls.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="DotNetNuke.WebUtility, Version=4.2.1.783, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.9.2.0.101\lib\net40\DotNetNuke.WebUtility.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Web.9.1.1.129\lib\net40\DotNetNuke.WebUtility.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="FiftyOne.Foundation, Version=3.2.3.2, Culture=neutral, PublicKeyToken=e967ae578dabd98e, processorArchitecture=MSIL">
+      <HintPath>packages\DotNetNuke.Bundle.9.1.1.129\lib\FiftyOne.Foundation.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationBlocks.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Core.9.2.0.73\lib\net40\Microsoft.ApplicationBlocks.Data.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Core.9.1.1.129\lib\net40\Microsoft.ApplicationBlocks.Data.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
@@ -145,7 +155,7 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="Telerik.Web.UI, Version=2013.2.717.40, Culture=neutral, PublicKeyToken=121fae78165ba3d4, processorArchitecture=MSIL">
-      <HintPath>packages\DotNetNuke.Web.Deprecated.9.2.0.101\lib\net40\Telerik.Web.UI.dll</HintPath>
+      <HintPath>packages\DotNetNuke.Web.Deprecated.9.1.1.129\lib\net40\Telerik.Web.UI.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
@@ -198,7 +208,6 @@
     <Content Include="Module.css" />
     <Content Include="ReleaseNotes.htm" />
     <Content Include="Settings.ascx" />
-    <None Include="packages.config" />
     <Content Include="Providers\DataProviders\SqlDataProvider\03.01.00.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\03.03.00.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\03.03.06.SqlDataProvider" />
@@ -208,6 +217,7 @@
     <Content Include="Providers\DataProviders\SqlDataProvider\04.01.01.SqlDataProvider" />
     <Content Include="README.md" />
     <Content Include="Providers\DataProviders\SqlDataProvider\Uninstall.SqlDataProvider" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App_LocalResources\EditLinks.ascx.resx" />
@@ -236,9 +246,9 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>18412</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://dnn920.localtest.me/DesktopModules/Dnn.Links</IISUrl>
+          <IISUrl>http://dnn911.localtest.me/DesktopModules/Dnn.Links</IISUrl>
           <OverrideIISAppRootUrl>True</OverrideIISAppRootUrl>
-          <IISAppRootUrl>http://dnn920.localtest.me</IISAppRootUrl>
+          <IISAppRootUrl>http://dnn911.localtest.me</IISAppRootUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/EditLinks.ascx.cs
+++ b/EditLinks.ascx.cs
@@ -57,6 +57,11 @@ namespace DotNetNuke.Modules.Links
     /// 	''' -----------------------------------------------------------------------------
     public partial class EditLinks : PortalModuleBase
     {
+        protected DotNetNuke.UI.UserControls.UrlControl ctlURL;
+        protected DotNetNuke.UI.UserControls.ModuleAuditControl ctlAudit;
+        protected DotNetNuke.UI.UserControls.URLTrackingControl ctlTracking;
+
+
         private int itemId = -1;
 
         protected override void OnInit(EventArgs e)

--- a/EditLinks.ascx.designer.cs
+++ b/EditLinks.ascx.designer.cs
@@ -64,16 +64,7 @@ namespace DotNetNuke.Modules.Links {
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.UserControl plURL;
-        
-        /// <summary>
-        /// ctlURL control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.UserControl ctlURL;
+        protected global::System.Web.UI.UserControl plURL;       
         
         /// <summary>
         /// tblGetContent control.
@@ -217,24 +208,7 @@ namespace DotNetNuke.Modules.Links {
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.WebControls.LinkButton cmdDelete;
-        
-        /// <summary>
-        /// ctlAudit control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.UserControl ctlAudit;
-        
-        /// <summary>
-        /// ctlTracking control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.UserControl ctlTracking;
+        protected global::System.Web.UI.WebControls.LinkButton cmdDelete;                        
+                
     }
 }

--- a/ReleaseNotes.htm
+++ b/ReleaseNotes.htm
@@ -1,4 +1,14 @@
-﻿<h2>Release notes DNN Links 07.00.00</h2>
+﻿<h2>Release notes DNN Links 07.00.01</h2>
+<p>Links Module 07.00.01 will work for DNN version 08.00.00 and has been tested up to Dnn 9.2.0</p>
+<h3>Bug fixes</h3>
+<ul>
+    <li>
+        Fixed build dependencies issues
+    </li>
+</ul>
+<hr />
+
+<h2>Release notes DNN Links 07.00.00</h2>
 <p>Links Module 07.00.0 will work for DNN version 07.02.00 and has been test up to Dnn 9.2.0</p>
 <h3>New features</h3>
 <ul>

--- a/packages.config
+++ b/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetNuke.Bundle" version="9.2.0.366" targetFramework="net45" />
-  <package id="DotNetNuke.Core" version="9.2.0.73" targetFramework="net45" />
-  <package id="DotNetNuke.Instrumentation" version="9.2.0.101" targetFramework="net45" />
-  <package id="DotNetNuke.Web" version="9.2.0.101" targetFramework="net45" />
-  <package id="DotNetNuke.Web.Client" version="9.2.0.101" targetFramework="net45" />
-  <package id="DotNetNuke.Web.Deprecated" version="9.2.0.101" targetFramework="net45" />
-  <package id="DotNetNuke.Web.Mvc" version="9.2.0.101" targetFramework="net45" />
-  <package id="DotNetNuke.WebApi" version="9.2.0.101" targetFramework="net45" />
+  <package id="DotNetNuke.Bundle" version="9.1.1.129" targetFramework="net45" />
+  <package id="DotNetNuke.Core" version="9.1.1.129" targetFramework="net45" />
+  <package id="DotNetNuke.Instrumentation" version="9.1.1.129" targetFramework="net45" />
+  <package id="DotNetNuke.Web" version="9.1.1.129" targetFramework="net45" />
+  <package id="DotNetNuke.Web.Client" version="9.1.1.129" targetFramework="net45" />
+  <package id="DotNetNuke.Web.Deprecated" version="9.1.1.129" targetFramework="net45" />
+  <package id="DotNetNuke.Web.Mvc" version="9.1.1.129" targetFramework="net45" />
+  <package id="DotNetNuke.WebApi" version="9.1.1.129" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net45" developmentDependency="true" />

--- a/packages.config
+++ b/packages.config
@@ -1,15 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetNuke.Bundle" version="9.1.1.129" targetFramework="net45" />
-  <package id="DotNetNuke.Core" version="9.1.1.129" targetFramework="net45" />
-  <package id="DotNetNuke.Instrumentation" version="9.1.1.129" targetFramework="net45" />
-  <package id="DotNetNuke.Web" version="9.1.1.129" targetFramework="net45" />
-  <package id="DotNetNuke.Web.Client" version="9.1.1.129" targetFramework="net45" />
-  <package id="DotNetNuke.Web.Deprecated" version="9.1.1.129" targetFramework="net45" />
-  <package id="DotNetNuke.Web.Mvc" version="9.1.1.129" targetFramework="net45" />
-  <package id="DotNetNuke.WebApi" version="9.1.1.129" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
+  <package id="DotNetNuke.Core" version="8.0.0.809" targetFramework="net45" />
+  <package id="DotNetNuke.Web" version="8.0.0.809" targetFramework="net45" />
+  <package id="DotNetNuke.Web.Deprecated" version="8.0.0.809" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net45" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="4.5.6" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The previous build dependencies where for Dnn 9.1.1 on builds that where only available on MyGet, so users without MyGet would not be able to build. Also, the module was marked as working from Dnn 7.2.0 up to 9.2.0 but some APIs where used that only exist in Dnn 8 and up

### Description of PR...
This marks the module compatible with Dnn 8 to 9.2 and gets Dnn 8 Nuget packages

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
Close #24 