### PR TITLE
Fixed an issue where setting Use Permissions would not apply

### DIFF
--- a/Links.ascx.cs
+++ b/Links.ascx.cs
@@ -748,7 +748,7 @@ namespace DotNetNuke.Modules.Links
                             if (this.ModuleContentType == Enums.ModuleContentTypes.Friends)
                                 isInARole = true;
 
-                            if (isInARole | link.GrantRoles.Contains(";-2;") | link.GrantRoles.Contains(";-1;") | this.UserInfo.IsSuperUser | this.UserInfo.IsInRole(this.PortalSettings.AdministratorRoleName))
+                            if (!this.UsePermissions | isInARole | link.GrantRoles.Contains(";-2;") | link.GrantRoles.Contains(";-1;") | this.UserInfo.IsSuperUser | this.UserInfo.IsInRole(this.PortalSettings.AdministratorRoleName))
 
                                 linksToShow.Add(link);
                         }

--- a/ReleaseNotes.htm
+++ b/ReleaseNotes.htm
@@ -5,6 +5,9 @@
     <li>
         Fixed build dependencies issues
     </li>
+    <li>
+        Fixed an issue where setting Use Permissions to No would have no effect after it was set to Yes.
+    </li>
 </ul>
 <hr />
 


### PR DESCRIPTION
### Description of PR...
Fixed an issue where setting Use Permissions to No would have no effect after it was set to Yes.

## Changes made
- Added a check to show links when the setting if false. Before this pull request, it would only work when null, so it would stop working after initially set to True.

## PR Template Checklist
- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
Closes #4