### PR TITLE
Fix for missing dbo/oq in DAL2 methods

### DIFF
--- a/Components/LinkController.cs
+++ b/Components/LinkController.cs
@@ -227,7 +227,7 @@ namespace DotNetNuke.Modules.Links.Components
         {
             using (var ctx = DataContext.Instance())
             {
-                return ctx.ExecuteQuery<Link>(System.Data.CommandType.StoredProcedure, "dnnLinks_GetLink", itemID, moduleId).FirstOrDefault();
+                return ctx.ExecuteQuery<Link>(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}dnnLinks_GetLink", itemID, moduleId).FirstOrDefault();
             }                
         }
 
@@ -235,7 +235,7 @@ namespace DotNetNuke.Modules.Links.Components
         {
             using (var ctx = DataContext.Instance())
             {
-                return ctx.ExecuteQuery<Link>(System.Data.CommandType.StoredProcedure, "dnnLinks_GetLinks", moduleId);
+                return ctx.ExecuteQuery<Link>(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}dnnLinks_GetLinks", moduleId);
             }
         }
 


### PR DESCRIPTION
When using an object qualifier the module will throw an error. This is because the placeholders are missing from the procedure name. This PR fixes that.