### PR TITLE
Fixed an issue where menu mode would show deleted or hidden pages

### DIFF
--- a/Links.ascx.cs
+++ b/Links.ascx.cs
@@ -542,7 +542,10 @@ namespace DotNetNuke.Modules.Links
                             {
                                 string moduleContentItem = Settings[Consts.ModuleContentItem].ToString();
                                 int.TryParse(moduleContentItem, out int moduleContentItemInt);
-                                tabsToShow = TabController.GetTabsByParent(moduleContentItemInt, this.PortalId);
+                                tabsToShow = TabController
+                                    .GetTabsByParent(moduleContentItemInt, this.PortalId)
+                                    .Where(tab => !tab.IsDeleted && tab.IsVisible &&!tab.DisableLink)
+                                    .ToList();
                             }
 
                             foreach (DotNetNuke.Entities.Tabs.TabInfo tabinfo in tabsToShow)


### PR DESCRIPTION
The menu mode used to show pages in the recycle bin, pages marked as disabled and pages marked as to not show in the menu. This PR filters those entries out of the menu mode.

Closes #45