### PR TITLE
Removed ID from list-item

### DIFF
--- a/Links.ascx
+++ b/Links.ascx
@@ -7,7 +7,7 @@
             <ul id="ulHeader" class="linklist <%# Horizontal %>" >
         </HeaderTemplate>
         <ItemTemplate>
-            <li id="itemLi" class="linkitem <%# Horizontal %>" <%# NoWrap %>>
+            <li class="linkitem <%# Horizontal %>" <%# NoWrap %>>
                 <asp:HyperLink ID="editLink" Visible="<%# IsEditable %>" runat="server">
                     <asp:Image ID="editLinkImage" ImageUrl="~/images/edit.gif" AlternateText="Edit" Visible="<%# IsEditable %>"
                         runat="server" />


### PR DESCRIPTION
WCAG 2.0 barks at duplicate IDs on the same page. The ID of the LI element was not actually used by anything so this PR removes it.

Closes #48